### PR TITLE
Move cycling policy to main page

### DIFF
--- a/improve-cycling-routes-and-rider-safety-discourage-car-use.md
+++ b/improve-cycling-routes-and-rider-safety-discourage-car-use.md
@@ -1,4 +1,0 @@
----
-title: Improve cycling routes and rider safety. Discourage car use.
----
-Improve cycling routes around Eastleigh by improving cycling routes, cannibalising existing road space where necessary. Reducing overall traffic speeds via both changing maximum speeds and traffic management infrastructure. Discourage the use of cars by implementing a highly effective Park and Ride and cutting back on parking, especially free parking.

--- a/index.md
+++ b/index.md
@@ -12,3 +12,9 @@ If you'd like to help write the manifesto, read the [contributor guide](contribu
 </div>
 
 **Note:** hopefully everything is now working well enough for early adopters to make a start writing a manifesto, although there are still likely to be some rough edges! If you find any problems, or if things don't make sense, [please open an issue](https://github.com/OpenEastleighPolitics/eastleigh-manifesto/issues/new?labels=bug).
+
+## Transport
+
+### Improve cycling routes and rider safety. Discourage car use.
+
+Improve cycling routes around Eastleigh by improving cycling routes, cannibalising existing road space where necessary. Reducing overall traffic speeds via both changing maximum speeds and traffic management infrastructure. Discourage the use of cars by implementing a highly effective Park and Ride and cutting back on parking, especially free parking.


### PR DESCRIPTION
The first manifesto policy wasn't visible so moving it to a transport
section on the main page

Signed-off-by: James Taylor <jt-git@nti.me.uk>