### PR TITLE
Add physical barriers between car and bike lanes to traffic policy

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ If you'd like to help write the manifesto, read the [contributor guide](contribu
 
 ### Improve cycling routes and rider safety. Discourage car use.
 
-Improve cycling routes around Eastleigh by improving cycling routes, cannibalising existing road space where necessary. Reducing overall traffic speeds via both changing maximum speeds and traffic management infrastructure. Discourage the use of cars by implementing a highly effective Park and Ride and cutting back on parking, especially free parking.
+Improve cycling routes around Eastleigh by improving cycling routes, cannibalising existing road space where necessary. Reducing overall traffic speeds via both changing maximum speeds and traffic management infrastructure. Discourage the use of cars by implementing a highly effective Park and Ride and cutting back on parking, especially free parking. Add physical barriers between bike lanes and car lanes.
 
 ## Lighting
 


### PR DESCRIPTION
This is common in places like the Netherlands.
Physical separation would decrease risk of bikes and cars colliding. It should encourage more people to cycle as increases sense of safety.
Car drivers would be less concerned of bikes swerving into their path.